### PR TITLE
Emergency patch: Solves failing build

### DIFF
--- a/Net/P2PClient.cs
+++ b/Net/P2PClient.cs
@@ -44,7 +44,7 @@ namespace MicroCoin.Net
 
         protected int WaitForData(int timeoutMs)
         {
-            while (TcpClient.Available == 0)
+            while (TcpClient.Available == 0);
             return TcpClient.Available;
         }
 


### PR DESCRIPTION
Fixed semicolon at line 47. The semicolon was removed in the megapatch yesterday, but it causes build failure.